### PR TITLE
Updated the maven.yml file to use self-hosted runner

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,17 +16,17 @@ on:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 20
-      uses: actions/setup-java@v3
-      with:
-        java-version: '20'
-        distribution: 'temurin'
-        cache: maven
-    - name: Run all tests
-      run: mvn clean test
+      - uses: actions/checkout@v4
+      - name: Set up JDK 20
+        uses: actions/setup-java@v3
+        with:
+          java-version: '20'
+          distribution: 'temurin'
+          cache: maven
+      - name: Run all tests
+        run: mvn clean test
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
 #    - name: Update dependency graph


### PR DESCRIPTION
Set up a new self hosted runner on the raspberry pi.

The pi will poll for new jobs, hence the connection does not need to come fro outside to my home internet. This prevents the issues with port forwarding.